### PR TITLE
Update Dockerfile RUN command

### DIFF
--- a/transcoding/Dockerfile
+++ b/transcoding/Dockerfile
@@ -5,9 +5,14 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN /usr/bin/apt-get update
-RUN /usr/bin/apt-get upgrade -y
-RUN /usr/bin/apt-get install -y pulseaudio xvfb firefox ffmpeg xdotool curl unzip
+RUN /usr/bin/apt-get update &&  /usr/bin/apt-get upgrade -y && /usr/bin/apt-get install -y \
+        pulseaudio \
+        xvfb \
+        firefox \
+        ffmpeg \
+        xdotool \
+        curl \
+        unzip
 
 COPY run.sh /
 RUN chmod +x /run.sh


### PR DESCRIPTION
Format the apt-get run command to resolve error of packages not found when running on new Cloud9 instance.

*Description of changes:*
When running this Dockerfile on a new AL2 Cloud9 I received an error 100 with packages not found.  Research led me to [here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/), noting that running `apt-get update` alone can cause caching issues.  The updated Dockerfile conforms to the best practices in the link above and resolves the build error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
