### PR TITLE
Hide microphone logo

### DIFF
--- a/transcoding/run.sh
+++ b/transcoding/run.sh
@@ -51,6 +51,11 @@ user_pref("media.gmp-gmpopenh264.version", "1.8.1.1");
 user_pref("doh-rollout.doorhanger-shown", true);
 EOF
 
+# Hide microphone logo
+cat <<EOF >> /tmp/foo4/prefs.js
+user_pref("privacy.webrtc.legacyGlobalIndicator", false);
+EOF
+
 # Start Firefox browser and point it at the URL we want to capture
 #
 # NB: The `--width` and `--height` arguments have to be very early in the


### PR DESCRIPTION
**Issue #:** #3 

**Description of changes:** Add Firefox preferences to hide microphone indicator

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
